### PR TITLE
Handle type error in handle_complete_intent_failure

### DIFF
--- a/neon_speech/__main__.py
+++ b/neon_speech/__main__.py
@@ -185,13 +185,13 @@ def handle_speak(event):
     bus.emit(Message('speak', event, context))
 
 
-def handle_complete_intent_failure(event):
+def handle_complete_intent_failure(message: Message):
     """Extreme backup for answering completely unhandled intent requests."""
     LOG.info("Failed to find intent.")
-    context = {'client_name': 'mycroft_listener',
-               'source': 'audio',
-               'destination': ["skills"]}
-    bus.emit(Message('complete.intent.failure', event, context))
+    # context = {'client_name': 'mycroft_listener',
+    #            'source': 'audio',
+    #            'destination': ["skills"]}
+    bus.emit(message.forward("complete.intent.failure", message.data))
 
 
 def handle_sleep(event):


### PR DESCRIPTION
Complete Intent Failure tries to pass a Message object as data. This forwards that message to retain context and provide expected behavior(?)

Not sure if this is actually utilized anywhere for Neon Core; maybe it should just be depreciated?