### PR TITLE
Resolve container config backwards-compatibility

### DIFF
--- a/docker_overlay/etc/neon/neon.yaml
+++ b/docker_overlay/etc/neon/neon.yaml
@@ -3,7 +3,7 @@ audio_parsers:
   - gender
 stt:
   module: deepspeech_stream_local
-  module_spec: neon-stt-plugin-deepspeech_stream_local
+  package_spec: neon-stt-plugin-deepspeech_stream_local>=1.0.1a0
   fallback_module: neon-stt-plugin-coqui
   ovos-stt-plugin-server:
     url: https://stt.openvoiceos.com/stt

--- a/neon_speech/listener.py
+++ b/neon_speech/listener.py
@@ -152,5 +152,12 @@ class NeonRecognizerLoop(RecognizerLoop):
         self.audio_consumer.start()
         self.audio_producer = AudioProducer(self)
         self.audio_producer.setName("audio_producer")
-        # if get_neon_device_type() != "server":
-        self.audio_producer.start()
+        try:
+            # TODO: Patching bug in ovos-core
+            self.microphone._start()
+            self.microphone._stop()
+            LOG.info("Microphone valid")
+            self.audio_producer.start()
+        except Exception as e:
+            LOG.exception(e)
+            LOG.error("Skipping audio_producer init")

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -44,7 +44,7 @@ from neon_utils.user_utils import apply_local_user_profile_updates
 from ovos_utils.json_helper import merge_dict
 from mycroft_bus_client import Message
 
-from mycroft.client.speech.service import SpeechClient
+from mycroft.client.speech.service import SpeechService
 from ovos_config.config import Configuration
 from neon_speech.listener import NeonRecognizerLoop
 from neon_speech.stt import STTFactory
@@ -70,7 +70,7 @@ def on_started():
     LOG.debug("Speech client started")
 
 
-class NeonSpeechClient(SpeechClient):
+class NeonSpeechClient(SpeechService):
     def __init__(self, ready_hook=on_ready, error_hook=on_error,
                  stopping_hook=on_stopping, alive_hook=on_alive,
                  started_hook=on_started, watchdog=lambda: None,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,8 +6,8 @@ pydub~=0.23
 click~=8.0
 click-default-group~=1.2
 neon_transformers~=0.1,>=0.1.1a0
-neon-utils[audio]>=1.0.0a11,<2.0.0
-ovos-config~=0.0,>=0.0.2a3
+neon-utils[audio]>=1.0.0a14,<2.0.0
+ovos-config~=0.0,>=0.0.3
 ovos-ww-plugin-pocketsphinx~=0.1.1
 ovos-ww-plugin-precise-lite~=0.1.0
 ovos-ww-plugin-precise~=0.1.0


### PR DESCRIPTION
Bump minimum neon-utils version
Fix typo in default config `module_spec`
Prevent AudioProducer init without a microphone