### PR TITLE
Install CPU-only pytorch from official source to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /neon_speech
 
 # cython included for Nemo package build
 RUN pip install wheel cython && \
+    pip install torch --extra-index-url https://download.pytorch.org/whl/cpu && \
     pip install .[docker]
 
 # Get vosk model for WW detection

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ WORKDIR /neon_speech
 
 # cython included for Nemo package build
 RUN pip install wheel cython && \
-    pip install torch --extra-index-url https://download.pytorch.org/whl/cpu && \
-    pip install .[docker]
+    pip install .[docker] --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Get vosk model for WW detection
 RUN mkdir -p /root/.local/share/neon && \


### PR DESCRIPTION
# Description
Install CPU-only torch to reduce image size per @NeonBohdan suggestion.

# Issues
Equivalent to https://github.com/NeonGeckoCom/neon_audio/pull/114

# Other Notes
Should improve image download delays as reported by @NeonDmitry