### PR TITLE
Identify default WW as active on the bus API

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt update
           sudo apt install portaudio19-dev python3-pyaudio libpulse-dev ffmpeg
           python -m pip install --upgrade pip
-          pip install cython
+          pip install cython wheel
           pip install . -r requirements/test_requirements.txt
       - name: Unit Tests
         run: |

--- a/neon_speech/listener.py
+++ b/neon_speech/listener.py
@@ -205,11 +205,12 @@ class NeonRecognizerLoop(RecognizerLoop):
             try:
                 self.engines[hotword]["engine"].stop()
                 LOG.debug(f"stopped {hotword}")
+                config = self.engines.pop(hotword)
+                if config.get('engine'):
+                    del config['engine']  # Make sure engine is removed
             except:
                 LOG.exception(f"Failed to stop hotword engine: {hotword}")
-            config = self.engines.pop(hotword)
-            if config.get('engine'):
-                del config['engine']  # Make sure engine is removed
+
         # wait for threads to shutdown
         try:
             if self.audio_producer and self.audio_producer.is_alive():

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -160,7 +160,8 @@ class NeonSpeechClient(SpeechService):
 
         active_ww = {ww: config for ww, config in
                      self.config.get('hotwords').items()
-                     if config.get('listen') and config.get('active', True)}
+                     if (config.get('listen') and config.get('active', True)) or
+                     ww == self.config['listener'].get('wake_word')}
         if requested_ww not in active_ww:
             LOG.warning(f"Requested disabling inactive ww: {requested_ww}")
             resp = message.response({"error": "ww already disabled",
@@ -227,6 +228,9 @@ class NeonSpeechClient(SpeechService):
         hotwords = self.config.get('hotwords')
         wake_words = {ww: config for ww, config in hotwords.items()
                       if config.get('listen')}
+        main_ww = self.config['listener'].get('wake_word')
+        if wake_words.get(main_ww):
+            wake_words[main_ww]['active'] = True
         self.bus.emit(message.reply("neon.wake_words", data=wake_words))
 
     def handle_profile_update(self, message):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,7 @@ pydub~=0.23
 click~=8.0
 click-default-group~=1.2
 neon-transformers~=0.2
-neon-utils[audio]~=1.2,>=1.2.2a5
+neon-utils[audio]~=1.2,>=1.2.2
 ovos-config~=0.0,>=0.0.6a1
 
 ovos-vad-plugin-webrtcvad~=0.0.1


### PR DESCRIPTION
# Description
Add handling for listener configured WW which defaults to `active`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->