### PR TITLE
Refactor STT init to reduce memory footprint

### DIFF
--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -118,7 +118,6 @@ class NeonSpeechClient(SpeechService):
         self.loop = NeonRecognizerLoop(self.bus, watchdog)
         self.connect_loop_events()
         self.connect_bus_events()
-        # TODO: Allow skipping api_stt init to reduce memory usage
         if self.config.get('listener', {}).get('enable_stt_api', True):
             self.api_stt = STTFactory.create(config=self.config,
                                              results_event=None)

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -118,8 +118,12 @@ class NeonSpeechClient(SpeechService):
         self.loop = NeonRecognizerLoop(self.bus, watchdog)
         self.connect_loop_events()
         self.connect_bus_events()
-        self.api_stt = STTFactory.create(config=self.config,
-                                         results_event=None)
+        # TODO: Allow skipping api_stt init to reduce memory usage
+        if self.config.get('listener', {}).get('enable_stt_api', True):
+            self.api_stt = STTFactory.create(config=self.config,
+                                             results_event=None)
+        else:
+            self.api_stt = None
 
     def shutdown(self):
         LOG.info("Shutting Down")
@@ -438,6 +442,9 @@ class NeonSpeechClient(SpeechService):
         audio_data = AudioData(segment.raw_data, segment.frame_rate,
                                segment.sample_width)
         audio_stream = get_audio_file_stream(wav_file)
+        if not self.api_stt:
+            raise RuntimeError("api_stt not initialized."
+                               " is `listener['enable_stt_api'] set to False?")
         if hasattr(self.api_stt, 'stream_start'):
             if self.lock.acquire(True, 30):
                 LOG.info(f"Starting STT processing (lang={lang}): {wav_file}")

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -123,6 +123,7 @@ class NeonSpeechClient(SpeechService):
             self.api_stt = STTFactory.create(config=self.config,
                                              results_event=None)
         else:
+            LOG.info("Skipping api_stt init")
             self.api_stt = None
 
     def shutdown(self):


### PR DESCRIPTION
# Description
Add an option to disable api_stt for low-resource devices (like Mark2)
Move fallback_stt init to first fallback call to reduce work done/memory used at init

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->