### PR TITLE
Refactor tests to remove messagebus module dependency

### DIFF
--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -3,4 +3,3 @@ neon-stt-plugin-nemo~=0.0
 ovos-stt-plugin-vosk~=0.1
 pytest
 mock~=4.0
-neon-messagebus~=0.2

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -31,6 +31,7 @@ import sys
 import mock
 import unittest
 
+from threading import Event
 from time import time
 from mycroft_bus_client import MessageBusClient, Message
 from neon_utils.configuration_utils import init_config_dir
@@ -50,6 +51,8 @@ AUDIO_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 class TestAPIMethodsStreaming(unittest.TestCase):
     speech_thread = None
     bus = FakeBus()
+    bus.connected_event = Event()
+    bus.connected_event.set()
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -229,6 +232,8 @@ class TestAPIMethodsStreaming(unittest.TestCase):
 class TestAPIMethodsNonStreaming(unittest.TestCase):
     speech_thread = None
     bus = FakeBus()
+    bus.connected_event = Event()
+    bus.connected_event.set()
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -35,7 +35,7 @@ from time import time
 from mycroft_bus_client import MessageBusClient, Message
 from neon_utils.configuration_utils import init_config_dir
 from neon_utils.file_utils import encode_file_to_base64_string
-from neon_messagebus.service import NeonBusService
+from ovos_utils.messagebus import FakeBus
 from ovos_utils.log import LOG
 from ovos_config.config import Configuration
 
@@ -49,6 +49,7 @@ AUDIO_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 
 class TestAPIMethodsStreaming(unittest.TestCase):
     speech_thread = None
+    bus = FakeBus()
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -61,10 +62,8 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         test_config["stt"]["module"] = "deepspeech_stream_local"
         assert test_config["stt"]["module"] == "deepspeech_stream_local"
 
-        cls.messagebus = NeonBusService(debug=True, daemonic=True)
-        cls.messagebus.start()
         cls.speech_service = NeonSpeechClient(speech_config=test_config,
-                                              daemonic=False)
+                                              daemonic=False, bus=cls.bus)
         cls.speech_service.start()
         cls.bus = MessageBusClient()
         cls.bus.run_in_thread()
@@ -83,10 +82,6 @@ class TestAPIMethodsStreaming(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         super(TestAPIMethodsStreaming, cls).tearDownClass()
-        try:
-            cls.messagebus.shutdown()
-        except Exception as e:
-            LOG.error(e)
         try:
             cls.speech_service.shutdown()
         except Exception as e:
@@ -233,6 +228,7 @@ class TestAPIMethodsStreaming(unittest.TestCase):
 
 class TestAPIMethodsNonStreaming(unittest.TestCase):
     speech_thread = None
+    bus = FakeBus()
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -245,10 +241,8 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
         test_config["stt"]["module"] = "neon-stt-plugin-nemo"
         assert test_config["stt"]["module"] == "neon-stt-plugin-nemo"
 
-        cls.messagebus = NeonBusService(debug=True, daemonic=True)
-        cls.messagebus.start()
         cls.speech_service = NeonSpeechClient(speech_config=test_config,
-                                              daemonic=False)
+                                              daemonic=False, bus=cls.bus)
         cls.speech_service.start()
         cls.bus = MessageBusClient()
         cls.bus.run_in_thread()
@@ -267,10 +261,6 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         super(TestAPIMethodsNonStreaming, cls).tearDownClass()
-        try:
-            cls.messagebus.shutdown()
-        except Exception as e:
-            LOG.error(e)
         try:
             cls.speech_service.shutdown()
         except Exception as e:

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -68,10 +68,6 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         cls.speech_service = NeonSpeechClient(speech_config=test_config,
                                               daemonic=False, bus=cls.bus)
         cls.speech_service.start()
-        cls.bus = MessageBusClient()
-        cls.bus.run_in_thread()
-        if not cls.bus.connected_event.wait(60):
-            raise TimeoutError("Bus not connected after 60 seconds")
         ready = False
         timeout = time() + 120
         while not ready and time() < timeout:
@@ -249,10 +245,6 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
         cls.speech_service = NeonSpeechClient(speech_config=test_config,
                                               daemonic=False, bus=cls.bus)
         cls.speech_service.start()
-        cls.bus = MessageBusClient()
-        cls.bus.run_in_thread()
-        if not cls.bus.connected_event.wait(60):
-            raise TimeoutError("Bus not connected after 60 seconds")
         ready = False
         timeout = time() + 120
         while not ready and time() < timeout:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -106,8 +106,11 @@ class UtilTests(unittest.TestCase):
             os.path.realpath(__file__)), "audio_files")
         TEST_CONFIG = use_neon_speech(Configuration)()
         TEST_CONFIG["stt"]["module"] = "deepspeech_stream_local"
+        bus = FakeBus()
+        bus.connected_event = Event()
+        bus.connected_event.set()
         client = NeonSpeechClient(speech_config=TEST_CONFIG, daemonic=True,
-                                  bus=FakeBus())
+                                  bus=bus)
         audio, context, transcripts = \
             client._get_stt_from_file(join(AUDIO_FILE_PATH, "stop.wav"))
         self.assertIsInstance(audio, AudioData)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -101,15 +101,13 @@ class UtilTests(unittest.TestCase):
     def test_get_stt_from_file(self):
         from neon_speech.service import NeonSpeechClient
         from neon_speech.utils import use_neon_speech
-        from neon_messagebus.service import NeonBusService
         from ovos_config.config import Configuration
         AUDIO_FILE_PATH = os.path.join(os.path.dirname(
             os.path.realpath(__file__)), "audio_files")
         TEST_CONFIG = use_neon_speech(Configuration)()
         TEST_CONFIG["stt"]["module"] = "deepspeech_stream_local"
-        bus = NeonBusService(daemonic=True)
-        bus.start()
-        client = NeonSpeechClient(speech_config=TEST_CONFIG, daemonic=True)
+        client = NeonSpeechClient(speech_config=TEST_CONFIG, daemonic=True,
+                                  bus=FakeBus())
         audio, context, transcripts = \
             client._get_stt_from_file(join(AUDIO_FILE_PATH, "stop.wav"))
         self.assertIsInstance(audio, AudioData)
@@ -133,10 +131,6 @@ class UtilTests(unittest.TestCase):
 
         for t in threads:
             t.join(30)
-        try:
-            bus.shutdown()
-        except Exception as e:
-            LOG.error(e)
 
     # TODO: Test other speech service methods directly
 


### PR DESCRIPTION
# Description
Update unit tests to drop neon-messagebus test dependency

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->