### PR TITLE
Specify Docker actions to use `diana` action runners

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -18,4 +18,4 @@ jobs:
     with:
       base_tag: base
       extra_tag: default_model
-      runner: self-hosted
+      runner: diana

--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       base_tag: base
       extra_tag: default_model
-      runner: self-hosted
+      runner: diana


### PR DESCRIPTION
# Description
Update Docker actions to explicitly use `diana` runners and not any self-hosted runners

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->