### PR TITLE
Kubernetes/No-audio server compat.

### DIFF
--- a/docker_overlay/etc/neon/neon.yaml
+++ b/docker_overlay/etc/neon/neon.yaml
@@ -57,6 +57,7 @@ sounds:
   start_listening: snd/start_listening.wav
   end_listening: snd/end_listening.wav
   acknowledge: snd/acknowledge.mp3
+  error: snd/error.mp3
 MQ:
   server: mq.2021.us
   port: 5672


### PR DESCRIPTION
# Description
Add config option to disable listener and only run API methods for k8s deployment
Handle read-only config file paths and fallback to `/tmp` for k8s compat.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->