### PR TITLE
Add timing metrics for minerva testing

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -8,3 +8,5 @@ on:
 jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
+    with:
+      packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|audioread).*'

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -378,10 +378,9 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
             with self._stopwatch:
                 _, parser_data, transcriptions = \
                     self._get_stt_from_file(wav_file_path, lang)
-            message.context.setdefault('timing', dict())
-            message.context['timing']['get_stt'] = self._stopwatch.time
             message.context["audio_parser_data"] = parser_data
             context = build_context(message)
+            context['timing']['get_stt'] = self._stopwatch.time
             data = {
                 "utterances": transcriptions,
                 "lang": message.data.get("lang", "en-us")

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -379,7 +379,7 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
                 _, parser_data, transcriptions = \
                     self._get_stt_from_file(wav_file_path, lang)
             message.context.setdefault('timing', dict())
-            message.context['timing']['get_stt'] = self._stopwatch.time()
+            message.context['timing']['get_stt'] = self._stopwatch.time
             message.context["audio_parser_data"] = parser_data
             context = build_context(message)
             data = {

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,5 +1,7 @@
 ovos-stt-plugin-vosk~=0.1
 neon-stt-plugin-nemo~=0.0.2
+onnxruntime!=1.16.0  # TODO: Patching https://github.com/microsoft/onnxruntime/issues/17631
+
 # Load alternative WW plugins so they are available
 ovos-ww-plugin-pocketsphinx~=0.1
 ovos-ww-plugin-precise-lite~=0.1

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -6,3 +6,4 @@ pytest
 mock~=4.0
 pydub~=0.23
 SpeechRecognition~=3.8
+onnxruntime!=1.16.0  # TODO: Patching https://github.com/microsoft/onnxruntime/issues/17631


### PR DESCRIPTION
# Description
Add `get_stt` timing metric for audio input

# Issues
https://github.com/NeonGeckoCom/neon-minerva/pull/3

# Other Notes
Includes patch for https://github.com/microsoft/onnxruntime/issues/17631
Updates license tests for dependency with undefined MIT license