### PR TITLE
Improved timing context handling with unit tests

### DIFF
--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -346,7 +346,7 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
                 ident, data={"error": f"{wav_file_path} Not found!"}))
 
         try:
-            message.context['timing'].setdefault(dict())
+            message.context.setdefault("timing", dict())
 
             _, parser_data, transcriptions = \
                 self._get_stt_from_file(wav_file_path, lang)

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -357,6 +357,7 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
             if received_time != sent_time:
                 message.context['timing']['client_to_core'] = \
                     received_time - sent_time
+            message.context['timing']['response_sent'] = time()
             self.bus.emit(message.reply(ident,
                                         data={"parser_data": parser_data,
                                               "transcripts": transcriptions}))

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -351,7 +351,7 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
             sent_time = message.context.get("timing", {}).get("client_sent",
                                                               received_time)
             if received_time != sent_time:
-                message.context['timing']['mq_from_client'] = \
+                message.context['timing']['client_to_core'] = \
                     received_time - sent_time
             self.bus.emit(message.reply(ident,
                                         data={"parser_data": parser_data,
@@ -386,7 +386,7 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
         sent_time = message.context.get("timing", {}).get("client_sent",
                                                           received_time)
         if received_time != sent_time:
-            message.context['timing']['mq_from_client'] = \
+            message.context['timing']['client_to_core'] = \
                 received_time - sent_time
         ident = message.context.get("ident") or "neon.audio_input.response"
         LOG.info(f"Handling audio input: {ident}")

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -395,14 +395,18 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
                 _, parser_data, transcriptions = \
                     self._get_stt_from_file(wav_file_path, lang)
             message.context["audio_parser_data"] = parser_data
+            message.context.setdefault('timing', dict())
             message.context['timing']['get_stt'] = self._stopwatch.time
             context = build_context(message)
             data = {
                 "utterances": transcriptions,
                 "lang": message.data.get("lang", "en-us")
             }
+            # Send a new message to the skills module with proper routing ctx
             handled = self._emit_utterance_to_skills(Message(
                 'recognizer_loop:utterance', data, context))
+
+            # Reply to original message with transcription/audio parser data
             self.bus.emit(message.reply(ident,
                                         data={"parser_data": parser_data,
                                               "transcripts": transcriptions,

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -105,6 +105,8 @@ class TestAPIMethodsStreaming(unittest.TestCase):
                                                       {}, context),
                                               context["ident"])
         self.assertEqual(stt_resp.context, context)
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("error"), str)
         self.assertEqual(stt_resp.data["error"], "audio_file not specified!")
 
@@ -117,6 +119,8 @@ class TestAPIMethodsStreaming(unittest.TestCase):
                     dict(context)), context["ident"])
         for key in context:
             self.assertEqual(stt_resp.context[key], context[key])
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("error"), str)
 
     def test_get_stt_invalid_file_type(self):
@@ -126,8 +130,11 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         stt_resp = self.bus.wait_for_response(
             Message("neon.get_stt",
                     {"audio_file": os.path.join(AUDIO_FILE_PATH, "test.txt")},
-                    context), context["ident"])
-        self.assertEqual(stt_resp.context, context)
+                    dict(context)), context["ident"])
+        for key in context:
+            self.assertEqual(stt_resp.context[key], context[key])
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("error"), str)
 
     def test_get_stt_valid_file(self):
@@ -138,11 +145,12 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         stt_resp = self.bus.wait_for_response(Message(
             "neon.get_stt", {"audio_file": os.path.join(AUDIO_FILE_PATH,
                                                         "stop.wav")},
-            context), context["ident"], 60.0)
+            dict(context)), context["ident"], 60.0)
         for key in context:
             if key != 'timing':
                 self.assertEqual(stt_resp.context[key], context[key])
-
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("parser_data"), dict,
                               stt_resp.serialize())
         self.assertIsInstance(stt_resp.data.get("transcripts"), list,
@@ -161,8 +169,11 @@ class TestAPIMethodsStreaming(unittest.TestCase):
                                                                "stop.wav"))
         stt_resp = self.bus.wait_for_response(Message(
             "neon.get_stt", {"audio_data": audio_data},
-            context), context["ident"], 60.0)
-        self.assertEqual(stt_resp.context, context)
+            dict(context)), context["ident"], 60.0)
+        for key in context:
+            self.assertEqual(stt_resp.context[key], context[key])
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("parser_data"), dict,
                               stt_resp.serialize())
         self.assertIsInstance(stt_resp.data.get("transcripts"), list,
@@ -308,9 +319,12 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
                    "ident": "123",
                    "user": "TestRunner"}
         stt_resp = self.bus.wait_for_response(Message("neon.get_stt",
-                                                      {}, context),
+                                                      {}, dict(context)),
                                               context["ident"])
-        self.assertEqual(stt_resp.context, context)
+        for key in context:
+            self.assertEqual(stt_resp.context[key], context[key])
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("error"), str)
         self.assertEqual(stt_resp.data["error"], "audio_file not specified!")
 
@@ -323,6 +337,8 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
                     dict(context)), context["ident"])
         for key in context:
             self.assertEqual(stt_resp.context[key], context[key])
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("error"), str)
 
     def test_get_stt_invalid_file_type(self):
@@ -332,8 +348,11 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
         stt_resp = self.bus.wait_for_response(
             Message("neon.get_stt",
                     {"audio_file": os.path.join(AUDIO_FILE_PATH, "test.txt")},
-                    context), context["ident"])
-        self.assertEqual(stt_resp.context, context)
+                    dict(context)), context["ident"])
+        for key in context:
+            self.assertEqual(stt_resp.context[key], context[key])
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("error"), str)
 
     def test_get_stt_valid_file(self):
@@ -343,8 +362,11 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
         stt_resp = self.bus.wait_for_response(Message(
             "neon.get_stt", {"audio_file": os.path.join(AUDIO_FILE_PATH,
                                                         "stop.wav")},
-            context), context["ident"], 60.0)
-        self.assertEqual(stt_resp.context, context)
+            dict(context)), context["ident"], 60.0)
+        for key in context:
+            self.assertEqual(stt_resp.context[key], context[key])
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("parser_data"), dict,
                               stt_resp.serialize())
         self.assertIsInstance(stt_resp.data.get("transcripts"), list,
@@ -359,8 +381,11 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
                                                                "stop.wav"))
         stt_resp = self.bus.wait_for_response(Message(
             "neon.get_stt", {"audio_data": audio_data},
-            context), context["ident"], 60.0)
-        self.assertEqual(stt_resp.context, context)
+            dict(context)), context["ident"], 60.0)
+        for key in context:
+            self.assertEqual(stt_resp.context[key], context[key])
+        self.assertIsInstance(stt_resp.context['timing']['response_sent'],
+                              float)
         self.assertIsInstance(stt_resp.data.get("parser_data"), dict,
                               stt_resp.serialize())
         self.assertIsInstance(stt_resp.data.get("transcripts"), list,

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -151,8 +151,6 @@ class TestAPIMethodsStreaming(unittest.TestCase):
                          context['timing']['client_sent'], stt_resp.context)
         self.assertIsInstance(stt_resp.context['timing']['mq_from_client'],
                               float, stt_resp.context)
-        self.assertIsInstance(stt_resp.context['timing']['transcribed'], float,
-                              stt_resp.context)
 
     def test_get_stt_valid_contents(self):
         context = {"client": "tester",
@@ -195,7 +193,8 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         self.assertIsInstance(message, Message)
         for key in context:
             self.assertIn(key, message.context)
-            self.assertEqual(context[key], message.context[key])
+            if key != "timing":
+                self.assertEqual(context[key], message.context[key])
         self.assertIsInstance(message.data["utterances"], list, message.data)
         self.assertIn("stop", message.data["utterances"],
                       message.data.get("utterances"))

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -114,8 +114,9 @@ class TestAPIMethodsStreaming(unittest.TestCase):
                    "user": "TestRunner"}
         stt_resp = self.bus.wait_for_response(
             Message("neon.get_stt", {"audio_file": "~/invalid_file.wav"},
-                    context), context["ident"])
-        self.assertEqual(stt_resp.context, context)
+                    dict(context)), context["ident"])
+        for key in context:
+            self.assertEqual(stt_resp.context[key], context[key])
         self.assertIsInstance(stt_resp.data.get("error"), str)
 
     def test_get_stt_invalid_file_type(self):
@@ -319,8 +320,9 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
                    "user": "TestRunner"}
         stt_resp = self.bus.wait_for_response(
             Message("neon.get_stt", {"audio_file": "~/invalid_file.wav"},
-                    context), context["ident"])
-        self.assertEqual(stt_resp.context, context)
+                    dict(context)), context["ident"])
+        for key in context:
+            self.assertEqual(stt_resp.context[key], context[key])
         self.assertIsInstance(stt_resp.data.get("error"), str)
 
     def test_get_stt_invalid_file_type(self):

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -184,7 +184,8 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         self.assertIsInstance(stt_resp, Message)
         for key in context:
             self.assertIn(key, stt_resp.context)
-            self.assertEqual(context[key], stt_resp.context[key])
+            if key != "timing":
+                self.assertEqual(context[key], stt_resp.context[key])
         self.assertIsInstance(stt_resp.data.get("skills_recv"), bool,
                               stt_resp.serialize())
         self.assertIsInstance(stt_resp.context['timing']['client_to_core'],
@@ -379,7 +380,8 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
         self.assertIsInstance(stt_resp, Message)
         for key in context:
             self.assertIn(key, stt_resp.context)
-            self.assertEqual(context[key], stt_resp.context[key])
+            if key != "timing":
+                self.assertEqual(context[key], stt_resp.context[key])
         self.assertIsInstance(stt_resp.data.get("skills_recv"), bool,
                               stt_resp.serialize())
 
@@ -388,7 +390,8 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
         self.assertIsInstance(message, Message)
         for key in context:
             self.assertIn(key, message.context)
-            self.assertEqual(context[key], message.context[key])
+            if key != "timing":
+                self.assertEqual(context[key], message.context[key])
         self.assertIsInstance(message.data["utterances"], list, message.data)
         self.assertIn("stop", message.data["utterances"],
                       message.data.get("utterances"))

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -149,7 +149,7 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         self.assertIn("stop", stt_resp.data.get("transcripts"))
         self.assertEqual(stt_resp.context['timing']['client_sent'],
                          context['timing']['client_sent'], stt_resp.context)
-        self.assertIsInstance(stt_resp.context['timing']['mq_from_client'],
+        self.assertIsInstance(stt_resp.context['timing']['client_to_core'],
                               float, stt_resp.context)
 
     def test_get_stt_valid_contents(self):
@@ -187,7 +187,7 @@ class TestAPIMethodsStreaming(unittest.TestCase):
             self.assertEqual(context[key], stt_resp.context[key])
         self.assertIsInstance(stt_resp.data.get("skills_recv"), bool,
                               stt_resp.serialize())
-        self.assertIsInstance(stt_resp.context['timing']['mq_from_client'],
+        self.assertIsInstance(stt_resp.context['timing']['client_to_core'],
                               float, stt_resp.context)
 
         handle_utterance.assert_called_once()
@@ -201,7 +201,7 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         self.assertIn("stop", message.data["utterances"],
                       message.data.get("utterances"))
         self.assertIsInstance(message.context["timing"], dict)
-        self.assertIsInstance(message.context['timing']['mq_from_client'],
+        self.assertIsInstance(message.context['timing']['client_to_core'],
                               float, message.context)
         self.assertIsInstance(message.context['timing']['transcribed'], float,
                               message.context)

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -132,7 +132,8 @@ class TestAPIMethodsStreaming(unittest.TestCase):
     def test_get_stt_valid_file(self):
         context = {"client": "tester",
                    "ident": "12345",
-                   "user": "TestRunner"}
+                   "user": "TestRunner",
+                   "timing": {"client_sent": time()}}
         stt_resp = self.bus.wait_for_response(Message(
             "neon.get_stt", {"audio_file": os.path.join(AUDIO_FILE_PATH,
                                                         "stop.wav")},
@@ -143,6 +144,11 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         self.assertIsInstance(stt_resp.data.get("transcripts"), list,
                               stt_resp.serialize())
         self.assertIn("stop", stt_resp.data.get("transcripts"))
+        self.assertEqual(stt_resp.context['timing']['client_sent'],
+                         context['timing']['client_sent'])
+        self.assertIsInstance(stt_resp.context['timing']['mq_from_client'],
+                              float)
+        self.assertIsInstance(stt_resp.context['timing']['transcribed'], float)
 
     def test_get_stt_valid_contents(self):
         context = {"client": "tester",

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -187,6 +187,8 @@ class TestAPIMethodsStreaming(unittest.TestCase):
             self.assertEqual(context[key], stt_resp.context[key])
         self.assertIsInstance(stt_resp.data.get("skills_recv"), bool,
                               stt_resp.serialize())
+        self.assertIsInstance(stt_resp.context['timing']['mq_from_client'],
+                              float, stt_resp.context)
 
         handle_utterance.assert_called_once()
         message = handle_utterance.call_args[0][0]
@@ -199,10 +201,10 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         self.assertIn("stop", message.data["utterances"],
                       message.data.get("utterances"))
         self.assertIsInstance(message.context["timing"], dict)
-        self.assertIsInstance(stt_resp.context['timing']['mq_from_client'],
-                              float, stt_resp.context)
-        self.assertIsInstance(stt_resp.context['timing']['transcribed'], float,
-                              stt_resp.context)
+        self.assertIsInstance(message.context['timing']['mq_from_client'],
+                              float, message.context)
+        self.assertIsInstance(message.context['timing']['transcribed'], float,
+                              message.context)
         self.assertEqual(message.context["destination"], ["skills"])
 
     def test_wake_words_state(self):

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -138,7 +138,10 @@ class TestAPIMethodsStreaming(unittest.TestCase):
             "neon.get_stt", {"audio_file": os.path.join(AUDIO_FILE_PATH,
                                                         "stop.wav")},
             context), context["ident"], 60.0)
-        self.assertEqual(stt_resp.context, context)
+        for key in context:
+            if key != 'timing':
+                self.assertEqual(stt_resp.context[key], context[key])
+
         self.assertIsInstance(stt_resp.data.get("parser_data"), dict,
                               stt_resp.serialize())
         self.assertIsInstance(stt_resp.data.get("transcripts"), list,

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -76,7 +76,7 @@ class TestAPIMethodsStreaming(unittest.TestCase):
 
         cls.speech_service = NeonSpeechClient(speech_config=test_config,
                                               daemonic=False, bus=cls.bus,
-                                              ready_hook=_ready())
+                                              ready_hook=_ready)
         assert cls.speech_service.config["stt"]["module"] == "deepspeech_stream_local"
         cls.speech_service.start()
 
@@ -181,7 +181,7 @@ class TestAPIMethodsStreaming(unittest.TestCase):
                                                                "stop.wav"))
         stt_resp = self.bus.wait_for_response(Message(
             "neon.audio_input", {"audio_data": audio_data},
-            context), context["ident"], 60.0)
+            dict(context)), context["ident"], 60.0)
         self.assertIsInstance(stt_resp, Message)
         for key in context:
             self.assertIn(key, stt_resp.context)
@@ -369,7 +369,7 @@ class TestAPIMethodsNonStreaming(unittest.TestCase):
                                                                "stop.wav"))
         stt_resp = self.bus.wait_for_response(Message(
             "neon.audio_input", {"audio_data": audio_data},
-            context), context["ident"], 60.0)
+            dict(context)), context["ident"], 60.0)
         self.assertIsInstance(stt_resp, Message)
         for key in context:
             self.assertIn(key, stt_resp.context)

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -148,10 +148,11 @@ class TestAPIMethodsStreaming(unittest.TestCase):
                               stt_resp.serialize())
         self.assertIn("stop", stt_resp.data.get("transcripts"))
         self.assertEqual(stt_resp.context['timing']['client_sent'],
-                         context['timing']['client_sent'])
+                         context['timing']['client_sent'], stt_resp.context)
         self.assertIsInstance(stt_resp.context['timing']['mq_from_client'],
-                              float)
-        self.assertIsInstance(stt_resp.context['timing']['transcribed'], float)
+                              float, stt_resp.context)
+        self.assertIsInstance(stt_resp.context['timing']['transcribed'], float,
+                              stt_resp.context)
 
     def test_get_stt_valid_contents(self):
         context = {"client": "tester",

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -176,7 +176,8 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         context = {"client": "tester",
                    "ident": "11111",
                    "user": "TestRunner",
-                   "extra_data": "something"}
+                   "extra_data": "something",
+                   "timing": {"client_sent": time()}}
         audio_data = encode_file_to_base64_string(os.path.join(AUDIO_FILE_PATH,
                                                                "stop.wav"))
         stt_resp = self.bus.wait_for_response(Message(
@@ -199,6 +200,10 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         self.assertIn("stop", message.data["utterances"],
                       message.data.get("utterances"))
         self.assertIsInstance(message.context["timing"], dict)
+        self.assertIsInstance(stt_resp.context['timing']['mq_from_client'],
+                              float, stt_resp.context)
+        self.assertIsInstance(stt_resp.context['timing']['transcribed'], float,
+                              stt_resp.context)
         self.assertEqual(message.context["destination"], ["skills"])
 
     def test_wake_words_state(self):


### PR DESCRIPTION
# Description
Allows for `timing` context sent from a connected client
Adds unit tests to validate timing context handling

# Issues
Continues #181

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->