### PR TITLE
Feature/plugin installation from config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN chmod ugo+x /root/run.sh
 
 RUN pip list
 
-RUN neon-speech install-plugin -f
+RUN neon-speech install-dependencies
 
 CMD ["/root/run.sh"]
 

--- a/docker_overlay/root/run.sh
+++ b/docker_overlay/root/run.sh
@@ -28,5 +28,5 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Plugin installation must occur in a separate thread, before module load, for the entry point to be loaded.
-neon-speech install-plugin -f
+neon-speech install-dependencies
 neon-speech run

--- a/neon_speech/cli.py
+++ b/neon_speech/cli.py
@@ -27,10 +27,14 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import click
+import sys
+from typing import List
 
 from click_default_group import DefaultGroup
 from neon_utils.packaging_utils import get_package_version_spec
 from neon_utils.configuration_utils import init_config_dir
+from ovos_config.config import Configuration
+from ovos_utils.log import LOG, log_deprecation
 
 
 @click.group("neon-speech", cls=DefaultGroup,
@@ -83,6 +87,7 @@ def run(module, package, force_install):
 @click.option("--force-install", "-f", default=False, is_flag=True,
               help="Force pip installation of configured module")
 def install_plugin(module, package, force_install):
+    log_deprecation("`install-plugin` replaced by `install-dependencies`", "2.0.0")
     from neon_speech.utils import install_stt_plugin
     from ovos_config.config import Configuration
     speech_config = Configuration()
@@ -97,6 +102,17 @@ def install_plugin(module, package, force_install):
         if not module:
             click.echo("Plugin specified without module")
 
+@neon_speech_cli.command(help="Install neon-speech module dependencies from config & cli")
+@click.option("--package", "-p", default=[], multiple=True,
+              help="Additional package to install (can be repeated)")
+def install_dependencies(package: List[str]):
+    from neon_utils.packaging_utils import install_packages_from_pip
+    from neon_speech.utils import build_extra_dependency_list
+    config = Configuration()
+    dependencies = build_extra_dependency_list(config, list(package))
+    result = install_packages_from_pip("neon-speech", dependencies)
+    LOG.info(f"pip exit code: {result}")
+    sys.exit(result)
 
 @neon_speech_cli.command(help="Install a STT Plugin")
 @click.option("--plugin", "-p", default=None,

--- a/neon_speech/utils.py
+++ b/neon_speech/utils.py
@@ -27,8 +27,10 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from tempfile import mkstemp
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 from neon_utils.packaging_utils import get_package_dependencies
+from ovos_config.config import Configuration
+from typing import List, Union
 
 
 def patch_config(config: dict = None):
@@ -58,7 +60,13 @@ def _plugin_to_package(plugin: str) -> str:
     }
     return known_plugins.get(plugin) or plugin
 
+def build_extra_dependency_list(config: Union[dict, Configuration], additional: List[str] = []) -> List[str]:
+    extra_dependencies = config.get("extra_dependencies", {})
+    dependencies = additional + extra_dependencies.get("global", []) + extra_dependencies.get("voice", [])
 
+    return dependencies
+
+@deprecated("Replaced by `neon_utils.packaging_utils.install_packages_from_pip`", "2.0.0")
 def install_stt_plugin(plugin: str) -> bool:
     """
     Install an stt plugin using pip

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@ ovos-utils~=0.0.30
 ovos-plugin-manager~=0.0.23
 click~=8.0
 click-default-group~=1.2
-neon-utils[network,audio]~=1.7
+neon-utils[network,audio]~=1.8,>=1.8.3a5
 ovos-config~=0.0.7
 
 ovos-vad-plugin-webrtcvad~=0.0.1


### PR DESCRIPTION
# Description

- Expand the entrypoint with an additional command, "install-dependencies" command
- Add utility function for building a dependency list from extra_dependencies and modules or fallbacks specified in TTS configuration
- Mark neon_speech.utils.install_stt_plugin as deprecated

# Issues
https://github.com/NeonGeckoCom/neon_enclosure/issues/84

# Other Notes
