### PR TITLE
Revert ovos-dinkum-listener dependency to previous validated version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ovos-dinkum-listener==0.0.3a35
+ovos-dinkum-listener==0.0.3a16
 ovos-bus-client~=0.0.3
 ovos-utils~=0.0,>=0.0.30
 ovos-plugin-manager~=0.0.23


### PR DESCRIPTION
# Description
Rolls back update to ovos-dinkum-listener dependency included in release 4.4.0

# Issues
https://github.com/OpenVoiceOS/ovos-dinkum-listener/issues/98
https://github.com/OpenVoiceOS/ovos-dinkum-listener/issues/107
https://github.com/OpenVoiceOS/ovos-dinkum-listener/issues/110

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->