### PR TITLE
Move STT timing to start at recording end

### DIFF
--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -35,7 +35,6 @@ from tempfile import mkstemp
 from threading import Lock, Event
 from time import time
 
-from ovos_utils.process_utils import ProcessState
 from pydub import AudioSegment
 from speech_recognition import AudioData
 from neon_utils.file_utils import decode_base64_string_to_file

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -34,6 +34,8 @@ import ovos_dinkum_listener.plugins
 from tempfile import mkstemp
 from threading import Lock, Event
 from time import time
+
+from ovos_utils.process_utils import ProcessState
 from pydub import AudioSegment
 from speech_recognition import AudioData
 from neon_utils.file_utils import decode_base64_string_to_file
@@ -135,9 +137,9 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
             LOG.info("Skipping api_stt init")
             self.api_stt = None
 
-    def _record_begin(self):
+    def _record_end_signal(self):
         self._stt_stopwatch.start()
-        OVOSDinkumVoiceService._record_begin(self)
+        OVOSDinkumVoiceService._record_end_signal(self)
 
     def _stt_text(self, text: str, stt_context: dict):
         self._stt_stopwatch.stop()


### PR DESCRIPTION
# Description
This makes interactions with the listener more directly comparable with API inputs by timing the same parts of the code.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
More consistent with [the docs](https://github.com/NeonGeckoCom/neon-docs/pull/30/files)