### PR TITLE
Refactor to extend changes in OvosDinkumListener

### DIFF
--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -129,8 +129,7 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
         self.lock = Lock()
         self._stop_service = Event()
         if self.config.get('listener', {}).get('enable_stt_api', True):
-            self.api_stt = STTFactory.create(config=self.config,
-                                             results_event=None)
+            self.api_stt = STTFactory.create(config=self.config)
         else:
             LOG.info("Skipping api_stt init")
             self.api_stt = None

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -220,6 +220,16 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
         self.bus.on("neon.enable_wake_word", self.handle_enable_wake_word)
         self.bus.on("neon.disable_wake_word", self.handle_disable_wake_word)
 
+        # TODO: Patching config reload behavior
+        self.bus.on("configuration.patch", self._patch_handle_config_reload)
+
+    def _patch_handle_config_reload(self, _: Message):
+        # This patches observed behavior where the filewatcher fails to trigger.
+        # Configuration reload is idempotent, so calling it again will have
+        # minimal impact
+        self.config.reload()
+        self.reload_configuration()
+
     def _handle_get_languages_stt(self, message):
         if self.config.get('listener', {}).get('enable_voice_loop', True):
             return OVOSDinkumVoiceService._handle_get_languages_stt(self,

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -48,9 +48,7 @@ from ovos_config.config import update_mycroft_config
 from ovos_dinkum_listener.service import OVOSDinkumVoiceService
 from ovos_dinkum_listener.voice_loop.voice_loop import ListeningMode
 
-from neon_speech.stt import STTFactory
-
-ovos_dinkum_listener.plugins.OVOSSTTFactory = STTFactory
+from ovos_plugin_manager.stt import OVOSSTTFactory as STTFactory
 
 _SERVICE_READY = Event()
 

--- a/neon_speech/stt.py
+++ b/neon_speech/stt.py
@@ -30,15 +30,21 @@ from abc import ABC
 from inspect import signature
 from threading import Event
 
-from neon_utils import LOG
+from ovos_utils.log import LOG, log_deprecation
 from ovos_plugin_manager.stt import OVOSSTTFactory, get_stt_config
 from ovos_plugin_manager.templates.stt import StreamingSTT
 
 from ovos_config.config import Configuration
 
+log_deprecation("This module is deprecated. Import from `ovos_plugin_manager`",
+                "5.0.0")
+
 
 class WrappedSTT(StreamingSTT, ABC):
     def __new__(cls, base_engine, *args, **kwargs):
+        log_deprecation("This class is deprecated. Use "
+                        "`ovos_plugin_manager.templates.stt.StreamingSTT",
+                        "5.0.0")
         results_event = kwargs.get("results_event") or Event()
         # build STT
         for k in list(kwargs.keys()):
@@ -66,6 +72,10 @@ class WrappedSTT(StreamingSTT, ABC):
 
 
 class STTFactory(OVOSSTTFactory):
+    log_deprecation("This class is deprecated. Use "
+                    "`ovos_plugin_manager.stt.OVOSSTTFactory",
+                    "5.0.0")
+
     @staticmethod
     def create(config=None, results_event: Event = None):
         get_stt_config(config)

--- a/neon_speech/utils.py
+++ b/neon_speech/utils.py
@@ -104,6 +104,7 @@ def init_stt_plugin(plugin: str):
         LOG.warning(f"Could not find plugin: {plugin}")
 
 
+@deprecated("Platform detection has been deprecated", "5.0.0")
 def use_neon_speech(func):
     """
     Wrapper to ensure call originates from neon_speech for stack checks.

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,5 +1,5 @@
 ovos-stt-plugin-vosk~=0.1
-neon-stt-plugin-nemo~=0.0.2,>=0.0.5a4
+neon-stt-plugin-nemo~=0.0.2,>=0.0.5a5
 onnxruntime!=1.16.0  # TODO: Patching https://github.com/microsoft/onnxruntime/issues/17631
 
 # Load alternative WW plugins so they are available

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,5 +1,5 @@
 ovos-stt-plugin-vosk~=0.1
-neon-stt-plugin-nemo~=0.0.2
+neon-stt-plugin-nemo~=0.0.2,>=0.0.5a4
 onnxruntime!=1.16.0  # TODO: Patching https://github.com/microsoft/onnxruntime/issues/17631
 
 # Load alternative WW plugins so they are available

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 ovos-dinkum-listener~=0.2
 ovos-bus-client~=0.0,>=0.0.3
 ovos-utils~=0.0,>=0.0.30
-ovos-plugin-manager~=0.1
+ovos-plugin-manager~=0.0,>=0.0.26a39
 click~=8.0
 click-default-group~=1.2
 neon-utils[network,audio]~=1.9,>=1.11.1a3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@ ovos-utils~=0.0,>=0.0.30
 ovos-plugin-manager~=0.0,>=0.0.23
 click~=8.0
 click-default-group~=1.2
-neon-utils[network,audio]~=1.9
+neon-utils[network,audio]~=1.9,>=1.11.1a3
 ovos-config~=0.0,>=0.0.7
 
 ovos-vad-plugin-webrtcvad~=0.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 ovos-dinkum-listener~=0.2
 ovos-bus-client~=0.0,>=0.0.3
 ovos-utils~=0.0,>=0.0.30
-ovos-plugin-manager~=0.0,>=0.0.23
+ovos-plugin-manager~=0.1
 click~=8.0
 click-default-group~=1.2
 neon-utils[network,audio]~=1.9,>=1.11.1a3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ovos-dinkum-listener~=0.0
+ovos-dinkum-listener~=0.2
 ovos-bus-client~=0.0,>=0.0.3
 ovos-utils~=0.0,>=0.0.30
 ovos-plugin-manager~=0.0,>=0.0.23
@@ -9,4 +9,4 @@ ovos-config~=0.0,>=0.0.7
 
 ovos-vad-plugin-webrtcvad~=0.0.1
 ovos-ww-plugin-vosk~=0.1
-ovos-microphone-plugin-alsa~=0.0.0
+ovos-microphone-plugin-alsa~=0.1

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,5 +1,4 @@
-neon-stt-plugin-deepspeech_stream_local~=2.0
-neon-stt-plugin-nemo~=0.0,>=0.0.2
+neon-stt-plugin-nemo~=0.0,>=0.0.5a4
 ovos-stt-plugin-vosk~=0.1
 ovos-stt-plugin-server~=0.0.3
 pytest

--- a/tests/api_method_tests.py
+++ b/tests/api_method_tests.py
@@ -65,9 +65,9 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         use_neon_speech(init_config_dir)()
 
         test_config = dict(Configuration())
-        test_config["stt"]["module"] = "deepspeech_stream_local"
+        test_config["stt"]["module"] = "neon-stt-plugin-nemo"
         test_config["listener"]["VAD"]["module"] = "dummy"
-        assert test_config["stt"]["module"] == "deepspeech_stream_local"
+        assert test_config["stt"]["module"] == "neon-stt-plugin-nemo"
 
         ready_event = Event()
 
@@ -77,7 +77,7 @@ class TestAPIMethodsStreaming(unittest.TestCase):
         cls.speech_service = NeonSpeechClient(speech_config=test_config,
                                               daemonic=False, bus=cls.bus,
                                               ready_hook=_ready)
-        assert cls.speech_service.config["stt"]["module"] == "deepspeech_stream_local"
+        assert cls.speech_service.config["stt"]["module"] == "neon-stt-plugin-nemo"
         cls.speech_service.start()
 
         if not ready_event.wait(120):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -230,8 +230,8 @@ class ServiceTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         from ovos_config.config import update_mycroft_config
-        from neon_utils.configuration_utils import init_config_dir
-        init_config_dir()
+        # from neon_utils.configuration_utils import init_config_dir
+        # init_config_dir()
 
         update_mycroft_config({"hotwords": cls.hotwords_config,
                                "stt": {"module": "neon-stt-plugin-nemo"},
@@ -239,11 +239,9 @@ class ServiceTests(unittest.TestCase):
         import importlib
         import ovos_config.config
         importlib.reload(ovos_config.config)
-        # from ovos_config.config import Configuration
-        # assert Configuration.xdg_configs[0]['hotwords'] == hotwords_config
+        from ovos_config.config import Configuration
+        assert Configuration.xdg_configs[0]['hotwords'] == cls.hotwords_config
 
-        from neon_speech.utils import use_neon_speech
-        use_neon_speech(init_config_dir)()
         from neon_speech.service import NeonSpeechClient
         cls.service = NeonSpeechClient(bus=cls.bus, ready_hook=cls.on_ready)
         # assert Configuration() == service.loop.config_core

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -117,7 +117,7 @@ class UtilTests(unittest.TestCase):
         AUDIO_FILE_PATH = os.path.join(os.path.dirname(
             os.path.realpath(__file__)), "audio_files")
         TEST_CONFIG = use_neon_speech(Configuration)()
-        TEST_CONFIG["stt"]["module"] = "deepspeech_stream_local"
+        TEST_CONFIG["stt"]["module"] = "neon-stt-plugin-nemo"
         bus = FakeBus()
         bus.connected_event = Event()
         bus.connected_event.set()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -133,7 +133,8 @@ class UtilTests(unittest.TestCase):
         self.assertIsInstance(audio, AudioData)
         self.assertIsInstance(context, dict)
         self.assertIsInstance(transcripts, list)
-        self.assertIn("stop", transcripts)
+        tr_str = [t[0] for t in transcripts]
+        self.assertIn("stop", tr_str)
 
         def threaded_get_stt():
             audio, context, transcripts = \
@@ -141,7 +142,8 @@ class UtilTests(unittest.TestCase):
             self.assertIsInstance(audio, AudioData)
             self.assertIsInstance(context, dict)
             self.assertIsInstance(transcripts, list)
-            self.assertIn("stop", transcripts)
+            tr_str = [t[0] for t in transcripts]
+            self.assertIn("stop", tr_str)
 
         threads = list()
         for i in range(0, 12):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -34,7 +34,8 @@ import unittest
 
 from os.path import dirname, join
 from threading import Thread, Event
-from unittest.mock import Mock, patch
+from unittest import skip
+from unittest.mock import patch
 from click.testing import CliRunner
 
 from ovos_bus_client import Message
@@ -44,6 +45,8 @@ from speech_recognition import AudioData
 
 CONFIG_PATH = os.path.join(dirname(__file__), "config")
 os.environ["XDG_CONFIG_HOME"] = CONFIG_PATH
+os.environ["OVOS_CONFIG_BASE_FOLDER"] = "neon"
+os.environ["OVOS_CONFIG_FILENAME"] = "neon.yaml"
 
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
@@ -80,12 +83,13 @@ class UtilTests(unittest.TestCase):
             "ovos-stt-plugin-vosk"))
         import ovos_stt_plugin_vosk
 
+    @skip("Configuration patching is deprecated")
     def test_patch_config(self):
         from neon_speech.utils import use_neon_speech
         from neon_utils.configuration_utils import init_config_dir
         test_config_dir = os.path.join(os.path.dirname(__file__), "config")
         os.makedirs(test_config_dir, exist_ok=True)
-        os.environ["XDG_CONFIG_HOME"] = test_config_dir
+
         use_neon_speech(init_config_dir)()
 
         with open(join(test_config_dir, "OpenVoiceOS", 'ovos.conf')) as f:
@@ -156,7 +160,7 @@ class UtilTests(unittest.TestCase):
         ovos_vosk_streaming = STTFactory().create(
             {'module': 'ovos-stt-plugin-vosk-streaming',
              'lang': 'en-us'})
-        self.assertIsInstance(ovos_vosk_streaming.results_event, Event)
+        # self.assertIsInstance(ovos_vosk_streaming.results_event, Event)
         test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  "audio_files", "stop.wav")
         from neon_utils.file_utils import get_audio_file_stream


### PR DESCRIPTION
# Description
Update to use OVOSSttFactory directly
Mark neon_speech.stt module as deprecated
Update dependencies to latest stable versions
Includes patch to handle config updates when FileWatcher fails to report changes

# Issues
Closes #168 
Relates to #158 

# Other Notes
Validated k8s alpha deployment
Tested local Docker instance
Tested against Mark2 latest beta