### PR TITLE
Update unit test and add manual Docker update automation

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11', '3.12']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
           sudo apt update
           sudo apt install portaudio19-dev python3-pyaudio libpulse-dev ffmpeg
           python -m pip install --upgrade pip
-          pip install cython wheel
+          pip install cython wheel setuptools
           pip install . -r requirements/test_requirements.txt
       - name: Unit Tests
         run: |

--- a/.github/workflows/update_docker_images.yml
+++ b/.github/workflows/update_docker_images.yml
@@ -1,0 +1,15 @@
+name: Publish Updated Docker image
+on:
+  workflow_dispatch:
+
+jobs:
+
+  build_and_publish_docker:
+    uses: neongeckocom/.github/.github/workflows/publish_docker.yml@master
+    secrets: inherit
+    with:
+      include_semver: False
+      base_tag: base
+      extra_tag: default_model
+      runner: diana
+      platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
# Description
Add Python3.12 and setuptools installation to unit test automation
Add GHA to manually update `dev` and `master` tagged images

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->