### PR TITLE
Update timing context reference to resolve exceptions

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -7,6 +7,6 @@ on:
       - master
 jobs:
   license_tests:
-    uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
+    uses: neongeckocom/.github/.github/workflows/license_tests.yml@FEAT_UpdateLicenseTestWhitelist
     # with:
     #   packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|audioread|RapidFuzz).*'

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -7,6 +7,4 @@ on:
       - master
 jobs:
   license_tests:
-    uses: neongeckocom/.github/.github/workflows/license_tests.yml@FEAT_UpdateLicenseTestWhitelist
-    # with:
-    #   packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|audioread|RapidFuzz).*'
+    uses: neongeckocom/.github/.github/workflows/license_tests.yml@master

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -8,5 +8,5 @@ on:
 jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
-    with:
-      packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|audioread|RapidFuzz).*'
+    # with:
+    #   packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|audioread|RapidFuzz).*'

--- a/neon_speech/service.py
+++ b/neon_speech/service.py
@@ -415,8 +415,8 @@ class NeonSpeechClient(OVOSDinkumVoiceService):
                 self._get_stt_from_file(wav_file_path, lang)
             timing = parser_data.pop('timing')
             message.context["timing"] = {**message.context["timing"], **timing}
-            sent_time = message.context["timing"].get("client_sent",
-                                                      received_time)
+            sent_time = message.context["timing"].get("client_sent") or \
+                received_time
             if received_time != sent_time:
                 message.context['timing']['client_to_core'] = \
                     received_time - sent_time


### PR DESCRIPTION
# Description
Refactor `timing` context reference to be safe when `None` values are specified

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Bug noted with input validation changes in https://github.com/NeonGeckoCom/neon-messagebus-mq-connector/pull/61